### PR TITLE
Show Device Details

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You should then be able to boot the USB and select the appropriate answer file.
 
 As soon as the ISO is loaded into the system you will be presented with a prompt asking for the appropriate information. In my config, I only needed the computer to prompt for the computer name. If you need access to more information in your environment you can modify the `/scripts/edit_unattend.bat` file accordingly.
 
-![](https://i.imgur.com/ibOcKXO.png)
+![](https://i.imgur.com/tJeiOGa.png)
 
 ---
 
@@ -95,4 +95,4 @@ For any modifications made to this file please refer to [Microsofts Documentatio
 
 Thanks for checking out my project.  If you have any questions or edits that you would like me to make to the config please let me know by posting a comment in the Issues section. [Link to issues](https://github.com/AdamKearn/windows-10-unattended-install/issues)
 
-A special thanks to Longpanda as this would not have been possible without having Ventoy.
+A special thanks to Longpanda as this would not have been possible without having [Ventoy](https://github.com/ventoy/ventoy).

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ As soon as the ISO is loaded into the system you will be presented with a prompt
 
 ![](https://i.imgur.com/tJeiOGa.png)
 
+As you can see from the image above it will show the MAC Address and Serial Number of the device you are booting off.
+
+If the device **does not** have Bitlocker enabled it will also be able to extract the previous computer name directly from the registry. This can be helpful when re-installing Windows and you want to keep your previous naming conventions.
+
 ---
 
 ## Modifying my config for your own needs:

--- a/scripts/edit_unattend.bat
+++ b/scripts/edit_unattend.bat
@@ -1,13 +1,38 @@
 @echo off
 
 if not exist "X:\Autounattend.xml" (GOTO EOF)
+for %%i in (C D E F G H I J K L N M O P Q R S T U V W Y Z) DO (if exist "%%i:\Windows\system32\config\system" (set old_win_install=%%i))
+
+:SHOW_OLD_DETAILS
+reg load "HKLM\_SYSTEM" "%old_win_install%:\Windows\system32\config\system"
+
+set OLD_PCNAME=FALLBACK
+for /f "tokens=2* skip=2" %%a in ('reg query "HKLM\_SYSTEM\ControlSet001\Control\ComputerName\ComputerName" /V "ComputerName"') do set OLD_PCNAME=%%b
+for /f "tokens=12" %%a in ('ipconfig /all ^|FIND /I "Physical Address"') do set MAC_ADDR=%%a
+for /f "tokens=2 delims==" %%a in ('wmic bios get serialnumber /format:value') do set SERIAL=%%a
+
+reg unload "HKLM\_SYSTEM"
 
 :START
 cls
-mode con:cols=60 lines=10
+mode con:cols=60 lines=13
 
 echo ============================================================
 echo               Pre-Windows Install Questions
+echo ============================================================
+echo.
+
+echo MAC: %MAC_ADDR%
+echo S/N: %SERIAL%
+echo.
+
+IF "%OLD_PCNAME:~0,7%"=="DESKTOP" (GOTO ASK_PCNAME)
+IF "%OLD_PCNAME:~0,6%"=="LAPTOP"  (GOTO ASK_PCNAME)
+IF "%OLD_PCNAME%"=="FALLBACK"     (GOTO ASK_PCNAME)
+
+echo Previous Computer Name: %OLD_PCNAME% && echo.
+
+:ASK_PCNAME
 echo ============================================================
 echo.
 


### PR DESCRIPTION
Modified the config to provide some additional details when booting.
This allows the end-user to quickly find the MAC, S/N or even the previous computer name.